### PR TITLE
[#35] Change field name mapping for Sponsoring Agency Logo

### DIFF
--- a/mapping.json
+++ b/mapping.json
@@ -37,7 +37,7 @@
   "from_field": "Sponsoring Agency",
   "type": "String"},
   {"name":"Sponsoring_Agency_Logo",
-  "from_field": "Agency_Logo_URL",
+  "from_field": "Agency Logo URL",
   "type": "String"},
   {"name": "Authorizing_Agency",
   "from_field": "Authorizing Agency",


### PR DESCRIPTION
Removed the underscores from the field name.